### PR TITLE
Add a runner for Lucene's graph kNN prototype.

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -107,43 +107,10 @@ float:
      constructor: FaissHNSW
      base-args: ["@metric"]
      run-groups:
-       M-4:
+       M-6:
          arg-groups:
-           - {"M": 4,  "efConstruction": 500}
+           - {"M": 6,  "efConstruction": 50}
          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-8:
-         arg-groups:
-           - {"M": 8,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-12:
-         arg-groups:
-           - {"M": 12,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-16:
-         arg-groups:
-           - {"M": 16,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-24:
-         arg-groups:
-           - {"M": 24,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-36:
-         arg-groups:
-           - {"M": 36,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-48:
-         arg-groups:
-           - {"M": 48,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-64:
-         arg-groups:
-           - {"M": 64,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-       M-96:
-         arg-groups:
-           - {"M": 96,  "efConstruction": 500}
-         query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
-
 
     flann:
      docker-tag: ann-benchmarks-flann

--- a/algos.yaml
+++ b/algos.yaml
@@ -1,5 +1,14 @@
 float:
   any:
+    lucene-graph:
+      docker-tag: ann-benchmarks-sklearn
+      module: ann_benchmarks.algorithms.lucene
+      constructor: LuceneGraph
+      base-args: ["@metric"]
+      run-groups:
+        base:
+          args: []
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
     sptag:
       docker-tag: ann-benchmarks-sptag
       module: ann_benchmarks.algorithms.sptag

--- a/ann_benchmarks/algorithms/lucene.py
+++ b/ann_benchmarks/algorithms/lucene.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+import numpy
+import sklearn.neighbors
+import sklearn.preprocessing
+
+from ann_benchmarks.distance import metrics as pd
+from ann_benchmarks.algorithms.base import BaseANN
+
+from py4j.java_collections import ListConverter
+from py4j.java_gateway import JavaGateway
+
+class LuceneGraph(BaseANN):
+    INDEX_BATCH_SIZE = 1000
+
+    def __init__(self, metric):
+        if metric not in ('angular', 'euclidean'):
+            raise NotImplementedError(
+                "LuceneGraph doesn't support metric %s" % metric)
+        self._metric = metric
+        self.gateway = JavaGateway()
+
+    def fit(self, X):
+        function = 'EUCLIDEAN' if self._metric is 'euclidean' else 'COSINE'
+        self.gateway.entry_point.prepareIndex(function)
+
+        start = 0
+        while start < X.shape[0]:
+            end = min(start + self.INDEX_BATCH_SIZE, X.shape[0])
+            batch = self.prepare_vectors(X[start:end])
+            self.gateway.entry_point.indexBatch(start, batch)
+            start = end
+
+        self.gateway.entry_point.forceMerge()
+        self.gateway.entry_point.openReader()
+
+    def query(self, v, n):
+        query_vector = self.prepare_vector(v)
+        return self.gateway.entry_point.search(query_vector, n, self.ef)
+
+    def set_query_arguments(self, ef):
+        self.ef = ef
+
+    def __str__(self):
+        return 'LuceneGraph(M=6, ef_const=50, ef={})'.format(self.ef)
+
+    def prepare_vectors(self, vectors):
+        converted_vectors = [self.prepare_vector(v) for v in vectors]
+        return ListConverter().convert(converted_vectors, self.gateway._gateway_client)
+
+    def prepare_vector(self, vector):
+        return ListConverter().convert(vector.tolist(), self.gateway._gateway_client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psutil==5.4.2
 scipy==1.0.0
 scikit-learn==0.19.1
 jinja2==2.10
+py4j==0.10.9


### PR DESCRIPTION
This branch gives a way to run benchmarks against Lucene's kNN prototypes. It uses py4j to connect to Lucene from the benchmarking framework.

To run benchmarks, first set up Lucene:
* Check out [this Lucene branch](https://github.com/jtibshirani/lucene-solr/tree/lucene-9004-aknn-2). It builds off the kNN prototype branch, and adds a class `PythonEntryPoint` to expose index + search functions.
* Run `PythonEntryPoint`, either from your IDE or from the commandline. Note that the jar `lucene/sandbox/py4j0.10.9.jar` must be on the classpath, as well as lucene sandbox and lucene core.

Then to run ann-benchmarks:
* Install the ann-benchmarks library through [these instructions](https://github.com/erikbern/ann-benchmarks#install). You can skip step 3, installing the Docker images.
* Make sure `py4j` is installed: `pip3 install py4j`.
* Run a benchmark in 'local' mode. Example command, which runs against a dataset of GloVe word vectors:
    ```
    python3 -u run.py --dataset glove-100-angular --algorithm lucene-graph \
           --force --runs 1 --local
    ```
* Print the results (this also creates plots under `results/`):
    ```
    python3 plot.py --dataset glove-100-angular
    ```

**Note**: converting from Python to Java through py4j likely adds non-trivial overhead. This benchmarking strategy is probably not best for measuring raw QPS, but can be useful (1) to examine recall numbers, and (2) to compare different Lucene kNN approaches against each other.