### PR TITLE
Add a runner for the coarse quantization kNN prototype.

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -1,5 +1,14 @@
 float:
   any:
+    lucene-cluster:
+      docker-tag: ann-benchmarks-sklearn
+      module: ann_benchmarks.algorithms.lucene
+      constructor: LuceneCluster
+      base-args: ["@metric"]
+      run-groups:
+        base:
+          args: []
+          query-args: [[2, 5, 10, 20, 50, 100]]
     sptag:
       docker-tag: ann-benchmarks-sptag
       module: ann_benchmarks.algorithms.sptag

--- a/ann_benchmarks/algorithms/lucene.py
+++ b/ann_benchmarks/algorithms/lucene.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+import numpy
+import sklearn.neighbors
+import sklearn.preprocessing
+
+from ann_benchmarks.distance import metrics as pd
+from ann_benchmarks.algorithms.base import BaseANN
+
+from py4j.java_collections import ListConverter
+from py4j.java_gateway import JavaGateway
+
+class LuceneCluster(BaseANN):
+    INDEX_BATCH_SIZE = 1000
+
+    def __init__(self, metric):
+        if metric not in ('angular', 'euclidean'):
+            raise NotImplementedError(
+                "LuceneCluster doesn't support metric %s" % metric)
+        self._metric = metric
+        self.gateway = JavaGateway()
+
+    def fit(self, X):
+        if self._metric == 'angular':
+            X = sklearn.preprocessing.normalize(X, axis=1, norm='l2')
+
+        self.gateway.entry_point.prepareIndex()
+
+        start = 0
+        while start < X.shape[0]:
+            end = min(start + self.INDEX_BATCH_SIZE, X.shape[0])
+            batch = self.prepare_vectors(X[start:end])
+            self.gateway.entry_point.indexBatch(start, batch)
+            start = end
+            print("Finished indexing {} vectors".format(end))
+
+        self.gateway.entry_point.mergeAndCommit()
+        self.gateway.entry_point.openReader()
+
+    def query(self, v, n):
+        if self._metric == 'angular':
+            v = sklearn.preprocessing.normalize([v], axis=1, norm='l2')[0]
+
+        query_vector = self.prepare_vector(v)
+        return self.gateway.entry_point.search(query_vector, n, self.n_probes)
+
+    def set_query_arguments(self, n_probes):
+        self.n_probes = n_probes
+
+    def __str__(self):
+        return 'LuceneCluster(n_probes={})'.format(self.n_probes)
+
+    def prepare_vectors(self, vectors):
+        converted_vectors = [self.prepare_vector(v) for v in vectors]
+        return ListConverter().convert(converted_vectors, self.gateway._gateway_client)
+
+    def prepare_vector(self, vector):
+        return ListConverter().convert(vector.tolist(), self.gateway._gateway_client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psutil==5.4.2
 scipy==1.0.0
 scikit-learn==0.19.1
 jinja2==2.10
+py4j==0.10.9


### PR DESCRIPTION
This branch gives a way to run benchmarks against Lucene kNN prototype based on coarse quantization (k-means clustering). It uses py4j to connect to Lucene from the benchmarking framework.

To run benchmarks, first set up Lucene:
* Check out [the Lucene branch](https://github.com/apache/lucene-solr/pull/1314) that contains the coarse quantization prototype.
* Run `PythonEntryPoint`, either from your IDE or from the commandline. Note that the jar `lucene/sandbox/py4j0.10.9.jar` must be on the classpath, as well as lucene sandbox and lucene core.

Then to run ann-benchmarks:
* Install the ann-benchmarks library through [these instructions](https://github.com/erikbern/ann-benchmarks#install). You can skip step 3, installing the Docker images.
* Make sure `py4j` is installed: `pip3 install py4j`.
* Run a benchmark in 'local' mode with batched queries. Example command, which runs against a dataset of GloVe word vectors:
    ```
    python3 -u run.py --dataset glove-100-angular --algorithm lucene-graph \
           --force --runs 1 --local --batch
    ```
* Print the results (this also creates plots under `results/`):
    ```
    python3 plot.py --dataset glove-100-angular
    ```

**Note**: converting from Python to Java through py4j can add ~5ms of overhead. We pass all queries to Lucene in batch to prevent this overhead from having a big impact on performance. Although they're provided in batch, the queries are run serially.